### PR TITLE
Use calloc, free; the objc_ variants are deprecated

### DIFF
--- a/WinUXTheme.m
+++ b/WinUXTheme.m
@@ -199,20 +199,12 @@ static inline RECT GSViewRectToWin(NSWindow *win, NSRect r)
   wchar_t* classNameChars;
   
   hWnd = (HWND)[[[NSView focusView] window] windowNumber];
-#ifdef _MSC_VER
   classNameChars = calloc([className length]+1, sizeof(wchar_t));
-#else  
-  classNameChars = objc_calloc([className length]+1, sizeof(wchar_t));
-#endif  
   [className getCharacters:classNameChars];
   
   hTheme = OpenThemeData(hWnd, classNameChars);
 
-#ifdef _MSC_VER
   free(classNameChars);
-#else  
-  objc_free(classNameChars);
-#endif  
   return hTheme;
 }
 


### PR DESCRIPTION
libobjc2 has deprecated `objc_calloc` and `objc_free`, so the code in its current form would fail when compiling with clang + libobjc2 on msys2.

Since the memory is allocated and freed in the same function I think it's safe to just always use `calloc` and `free`.