### PR TITLE
WinUXTheme: Override menu visibility

### DIFF
--- a/WinUXTheme.m
+++ b/WinUXTheme.m
@@ -237,7 +237,13 @@ static inline RECT GSViewRectToWin(NSWindow *win, NSRect r)
     return YES;
   else 
     return NO;
-} 
+}
+
+- (BOOL) proposedVisibility: (BOOL)visible
+	 forMenu: (NSMenu *) menu
+{
+  return YES;
+}
 @end
 
 


### PR DESCRIPTION
The default implementation of `[NSMenu _isVisible]` will use the `_aWindow`  and `_bWindow` windows.  However, WinUXTheme does not use these windows, and the value of `_isVisible` will be incorrect.  Override the value by implementing `proposedVisibility: forMenu`, and always return `TRUE`.