### PR TITLE
CI: Bump runner to windows-2022

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
   mingw:
     strategy:
       matrix:
-        os: [ windows-2019 ]
+        os: [ windows-2022 ]
         msystem: [ ucrt64, mingw64, clang64 ]
         include:
           - msystem: ucrt64

--- a/WinNSBrowserHeader.m
+++ b/WinNSBrowserHeader.m
@@ -36,7 +36,7 @@
   // otherwise, do nothing...
   if(!IsThemeActive())
     {
-      [super drawBrowserHeaderCell: cell
+      [super drawBrowserHeaderCell: (NSTableHeaderCell *)cell
 			 withFrame: rect
 			    inView: view];
     }

--- a/WinNSMenu.m
+++ b/WinNSMenu.m
@@ -552,7 +552,7 @@ void delete_menu(HWND win)
     {
       NSRectEdge sides[] = {NSMinYEdge, NSMaxXEdge, NSMaxYEdge, NSMinXEdge,
 			    NSMinYEdge, NSMaxXEdge};
-      float      grays[] = {NSBlack, NSBlack, NSBlack, NSBlack, 
+      CGFloat    grays[] = {NSBlack, NSBlack, NSBlack, NSBlack, 
 			    NSDarkGray, NSDarkGray};
 
      [[NSColor whiteColor] set];


### PR DESCRIPTION
The windows-2019 image has been deprecated in June 2025: https://github.com/actions/runner-images/issues/12045